### PR TITLE
Removed travis builds for php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: php
 php:
   - 5.3
   - 5.4
-  - 5.5
-
-matrix:
-    allow_failure:
-        - php: 5.5
 
 before_script:
     - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
Currently they are timming out which makes the travis builds very long.
