### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "braintree/braintree_php": "2.25.*"
+        "braintree/braintree_php": "*"
     },
     "require-dev": {
         "symfony/framework-bundle": ">=2.2,<2.3-dev",


### PR DESCRIPTION
Put 2.25.\* instead of dev-master because it does not working for me with dev-master:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for cometcult/braintree-bundle dev-master -> satisfiable by cometcult/braintree-bundle[dev-master].
    - cometcult/braintree-bundle dev-master requires braintree/braintree_php dev-master -> no matching package found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
